### PR TITLE
Update supported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - hhvm
+  - 7.1
+  - 7.2
+  - nightly
 
 install:
   - composer self-update
   - composer install --dev --no-interaction
+
+allowed_failures:
+  - nightly
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
         "psr-0": {
             "PHPHtmlParser": "src/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.8.x-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "paquettg/string-encode": "~0.1.0"
+        "php": "^7.1",
+        "paquettg/string-encode": "^0.1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.3.0",
-        "satooshi/php-coveralls": "~1.0.0",
-        "mockery/mockery": "~0.9.0"
+        "phpunit/phpunit": "^6.5",
+        "php-coveralls/php-coveralls": "^2.0",
+        "mockery/mockery": "^1.0"
     },
     "replace": {
         "paquettg/php-html-parser": "self.version"
@@ -33,6 +33,5 @@
         "psr-0": {
             "PHPHtmlParser": "src/"
         }
-    },
-    "prefer-stable": true
+    }
 }

--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -359,8 +359,8 @@ class Dom
         }
 
         // remove white space before closing tags
-        $str = mb_eregi_replace("'\s+>", "'>", $str);
-        $str = mb_eregi_replace('"\s+>', '">', $str);
+        $str = preg_replace("#'\s+>#i", "'>", $str);
+        $str = preg_replace('#"\s+>#i', '">', $str);
 
         // clean out the \n\r
         $replace = ' ';
@@ -370,31 +370,31 @@ class Dom
         $str = str_replace(["\r\n", "\r", "\n"], $replace, $str);
 
         // strip the doctype
-        $str = mb_eregi_replace("<!doctype(.*?)>", '', $str);
+        $str = preg_replace("#<!doctype(.*?)>#i", '', $str);
 
         // strip out comments
-        $str = mb_eregi_replace("<!--(.*?)-->", '', $str);
+        $str = preg_replace("#<!--(.*?)-->#i", '', $str);
 
         // strip out cdata
-        $str = mb_eregi_replace("<!\[CDATA\[(.*?)\]\]>", '', $str);
+        $str = preg_replace("#<!\[CDATA\[(.*?)\]\]>#i", '', $str);
 
         // strip out <script> tags
         if ($this->options->get('removeScripts') == true) {
-            $str = mb_eregi_replace("<\s*script[^>]*[^/]>(.*?)<\s*/\s*script\s*>", '', $str);
-            $str = mb_eregi_replace("<\s*script\s*>(.*?)<\s*/\s*script\s*>", '', $str);
+            $str = preg_replace("#<\s*script[^>]*[^/]>(.*?)<\s*/\s*script\s*>#i", '', $str);
+            $str = preg_replace("#<\s*script\s*>(.*?)<\s*/\s*script\s*>#i", '', $str);
         }
 
         // strip out <style> tags
         if ($this->options->get('removeStyles') == true) {
-            $str = mb_eregi_replace("<\s*style[^>]*[^/]>(.*?)<\s*/\s*style\s*>", '', $str);
-            $str = mb_eregi_replace("<\s*style\s*>(.*?)<\s*/\s*style\s*>", '', $str);
+            $str = preg_replace("#<\s*style[^>]*[^/]>(.*?)<\s*/\s*style\s*>#", '', $str);
+            $str = preg_replace("#<\s*style\s*>(.*?)<\s*/\s*style\s*>#", '', $str);
         }
 
         // strip out server side scripts
-        $str = mb_eregi_replace("(<\?)(.*?)(\?>)", '', $str);
+        $str = preg_replace("#(<\?)(.*?)(\?>)#i", '', $str);
 
         // strip smarty scripts
-        $str = mb_eregi_replace("(\{\w)(.*?)(\})", '', $str);
+        $str = preg_replace("#(\{\w)(.*?)(\})#i", '', $str);
 
         return $str;
     }

--- a/src/PHPHtmlParser/Dom/TextNode.php
+++ b/src/PHPHtmlParser/Dom/TextNode.php
@@ -38,7 +38,7 @@ class TextNode extends LeafNode
     public function __construct($text)
     {
         // remove double spaces
-        $text = mb_ereg_replace('\s+', ' ', $text);
+        $text = preg_replace('#\s+#', ' ', $text);
 
         // restore line breaks
         $text = str_replace('&#10;', "\n", $text);

--- a/src/PHPHtmlParser/Selector.php
+++ b/src/PHPHtmlParser/Selector.php
@@ -168,8 +168,7 @@ class Selector
     protected function seek(array $nodes, array $rule, array $options)
     {
         // XPath index
-        if (count($rule['tag']) > 0 &&
-            count($rule['key']) > 0 &&
+        if (!empty($rule['tag']) &&
             is_numeric($rule['key'])
         ) {
             $count = 0;

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -4,8 +4,9 @@ use PHPHtmlParser\Selector;
 use PHPHtmlParser\Dom\HtmlNode;
 use PHPHtmlParser\Dom\Tag;
 use PHPHtmlParser\Dom\Collection;
+use PHPUnit\Framework\TestCase;
 
-class CollectionTest extends PHPUnit_Framework_TestCase {
+class CollectionTest extends TestCase {
     
     public function testEach()
     {
@@ -29,10 +30,10 @@ class CollectionTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException PHPHtmlParser\Exceptions\EmptyCollectionException
      */
     public function testCallNoNodes()
     {
+        $this->expectException('PHPHtmlParser\Exceptions\EmptyCollectionException');
         $collection = new Collection();
         $collection->innerHtml();
     }
@@ -70,10 +71,10 @@ class CollectionTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException PHPHtmlParser\Exceptions\EmptyCollectionException
      */
     public function testGetNoNodes()
     {
+        $this->expectException('PHPHtmlParser\Exceptions\EmptyCollectionException');
         $collection = new Collection();
         $collection->innerHtml;
     }

--- a/tests/ContentTest.php
+++ b/tests/ContentTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHPHtmlParser\Content;
+use PHPUnit\Framework\TestCase;
 
-class ContentTest extends PHPUnit_Framework_TestCase {
+class ContentTest extends TestCase {
 
     public function testChar()
     {

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -147,21 +147,21 @@ class DomTest extends PHPUnit_Framework_TestCase {
     public function testLoadWithFile()
     {
         $dom = new Dom;
-        $dom->loadFromFile('tests/files/small.html');
+        $dom->loadFromFile(__DIR__ . '/files/small.html');
         $this->assertEquals('VonBurgermeister', $dom->find('.post-user font', 0)->text);
     }
 
     public function testLoadFromFile()
     {
         $dom = new Dom;
-        $dom->loadFromFile('tests/files/small.html');
+        $dom->loadFromFile(__DIR__ . '/files/small.html');
         $this->assertEquals('VonBurgermeister', $dom->find('.post-user font', 0)->text);
     }
 
     public function testLoadFromFileFind()
     {
         $dom = new Dom;
-        $dom->loadFromFile('tests/files/small.html');
+        $dom->loadFromFile(__DIR__ . '/files/small.html');
         $this->assertEquals('VonBurgermeister', $dom->find('.post-row div .post-user font', 0)->text);
     }
 
@@ -175,14 +175,14 @@ class DomTest extends PHPUnit_Framework_TestCase {
     public function testLoadFileBig()
     {
         $dom = new Dom;
-        $dom->loadFromFile('tests/files/big.html');
+        $dom->loadFromFile(__DIR__ . '/files/big.html');
         $this->assertEquals(10, count($dom->find('.content-border')));
     }
 
     public function testLoadFileBigTwice()
     {
         $dom = new Dom;
-        $dom->loadFromFile('tests/files/big.html');
+        $dom->loadFromFile(__DIR__ . '/files/big.html');
         $post = $dom->find('.post-row', 0);
         $this->assertEquals(' <p>Журчанье воды<br /> Черно-белые тени<br /> Вновь на фонтане</p> ', $post->find('.post-message', 0)->innerHtml);
     }
@@ -190,7 +190,7 @@ class DomTest extends PHPUnit_Framework_TestCase {
     public function testLoadFileBigTwicePreserveOption()
     {
         $dom = new Dom;
-        $dom->loadFromFile('tests/files/big.html', ['preserveLineBreaks' => true]);
+        $dom->loadFromFile(__DIR__ . '/files/big.html', ['preserveLineBreaks' => true]);
         $post = $dom->find('.post-row', 0);
         $this->assertEquals('<p>Журчанье воды<br />
 Черно-белые тени<br />
@@ -203,7 +203,7 @@ class DomTest extends PHPUnit_Framework_TestCase {
         $curl->shouldReceive('get')
              ->once()
              ->with('http://google.com')
-             ->andReturn(file_get_contents('tests/files/small.html'));
+             ->andReturn(file_get_contents(__DIR__ . '/files/small.html'));
         
         $dom = new Dom;
         $dom->loadFromUrl('http://google.com', [], $curl);
@@ -262,7 +262,7 @@ class DomTest extends PHPUnit_Framework_TestCase {
     public function testEnforceEncoding()
     {
         $dom = new Dom;
-        $dom->load('tests/files/horrible.html', [
+        $dom->load(__DIR__ . '/files/horrible.html', [
             'enforceEncoding' => 'UTF-8',
         ]);
         $this->assertNotEquals('<input type="submit" tabindex="0" name="submit" value="Информации" />', $dom->find('table input', 1)->outerHtml);

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use PHPHtmlParser\Dom;
+use PHPHtmlParser\Exceptions\NotLoadedException;
+use PHPUnit\Framework\TestCase;
 
-class DomTest extends PHPUnit_Framework_TestCase {
+class DomTest extends TestCase {
 
     public function tearDown()
     {
@@ -17,11 +19,9 @@ class DomTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('<div class="all"><p>Hey bro, <a href="google.com">click here</a><br /> :)</p></div>', $div->outerHtml);
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\NotLoadedException
-     */
     public function testNotLoaded()
     {
+        $this->expectException(NotLoadedException::class);
         $dom = new Dom;
         $div = $dom->find('div', 0);
     }

--- a/tests/Node/ChildrenTest.php
+++ b/tests/Node/ChildrenTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use PHPHtmlParser\Dom\MockNode as Node;
+use PHPHtmlParser\Exceptions\ChildNotFoundException;
+use PHPHtmlParser\Exceptions\ParentNotFoundException;
+use PHPUnit\Framework\TestCase;
 
-class NodeChildTest extends PHPUnit_Framework_TestCase {
+class NodeChildTest extends TestCase {
 
     public function testGetParent()
     {
@@ -32,22 +35,20 @@ class NodeChildTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($child2->id(), $child->nextSibling()->id());
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\ChildNotFoundException
-     */
     public function testNextSiblingNotFound()
     {
+        $this->expectException(ChildNotFoundException::class);
+
         $parent = new Node;
         $child  = new Node;
         $child->setParent($parent);
         $child->nextSibling();
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\ParentNotFoundException
-     */
     public function testNextSiblingNoParent()
     {
+        $this->expectException(ParentNotFoundException::class);
+
         $child = new Node;
         $child->nextSibling();
     }
@@ -62,22 +63,20 @@ class NodeChildTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($child->id(), $child2->previousSibling()->id());
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\ChildNotFoundException
-     */
     public function testPreviousSiblingNotFound()
     {
+        $this->expectException(ChildNotFoundException::class);
+
         $parent = new Node;
         $node = new Node;
         $node->setParent($parent);
         $node->previousSibling();
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\ParentNotFoundException
-     */
     public function testPreviousSiblingNoParent()
     {
+        $this->expectException(ParentNotFoundException::class);
+
         $child = new Node;
         $child->previousSibling();
     }

--- a/tests/Node/HtmlTest.php
+++ b/tests/Node/HtmlTest.php
@@ -5,8 +5,11 @@ use PHPHtmlParser\Dom\HtmlNode;
 use PHPHtmlParser\Dom\TextNode;
 use PHPHtmlParser\Dom\MockNode;
 use PHPHtmlParser\Dom\Tag;
+use PHPHtmlParser\Exceptions\ParentNotFoundException;
+use PHPHtmlParser\Exceptions\UnknownChildTypeException;
+use PHPUnit\Framework\TestCase;
 
-class NodeHtmlTest extends PHPUnit_Framework_TestCase {
+class NodeHtmlTest extends TestCase {
 
     public function testInnerHtml()
     {
@@ -65,11 +68,10 @@ class NodeHtmlTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($inner, $parent->innerHtml());
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\UnknownChildTypeException
-     */
     public function testInnerHtmlUnkownChild()
     {
+        $this->expectException(UnknownChildTypeException::class);
+
         $div = new Tag('div');
         $div->setAttributes([
             'class' => [
@@ -447,11 +449,10 @@ class NodeHtmlTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(2, $children);
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\ParentNotFoundException
-     */
     public function testAncestorByTagFailure()
     {
+        $this->expectException(ParentNotFoundException::class);
+
         $a    = new Tag('a');
         $node = new HtmlNode($a);
         $node->ancestorByTag('div');

--- a/tests/Node/ParentTest.php
+++ b/tests/Node/ParentTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use PHPHtmlParser\Dom\MockNode as Node;
+use PHPHtmlParser\Exceptions\CircularException;
+use PHPUnit\Framework\TestCase;
 
-class NodeParentTest extends PHPUnit_Framework_TestCase {
+class NodeParentTest extends TestCase {
 
     public function testHasChild()
     {
@@ -150,33 +152,30 @@ class NodeParentTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($parent->isChild($child->id()));
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\CircularException
-     */
     public function testSetParentDescendantException()
     {
+        $this->expectException(CircularException::class);
+
         $parent = new Node;
         $child  = new Node;
         $parent->addChild($child);
         $parent->setParent($child);
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\CircularException
-     */
     public function testAddChildAncestorException()
     {
+        $this->expectException(CircularException::class);
+
         $parent = new Node;
         $child  = new Node;
         $parent->addChild($child);
         $child->addChild($parent);
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\CircularException
-     */
     public function testAddItselfAsChild()
     {
+        $this->expectException(CircularException::class);
+
         $parent = new Node;
         $parent->addChild($parent);
     }

--- a/tests/Node/TagTest.php
+++ b/tests/Node/TagTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHPHtmlParser\Dom\Tag;
+use PHPUnit\Framework\TestCase;
 
-class NodeTagTest extends PHPUnit_Framework_TestCase {
+class NodeTagTest extends TestCase {
 
     public function testSelfClosing()
     {

--- a/tests/Node/TextTest.php
+++ b/tests/Node/TextTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHPHtmlParser\Dom\TextNode;
+use PHPUnit\Framework\TestCase;
 
-class NodeTextTest extends PHPUnit_Framework_TestCase {
+class NodeTextTest extends TestCase {
 
     public function testText()
     {

--- a/tests/Options/CleanupTest.php
+++ b/tests/Options/CleanupTest.php
@@ -10,7 +10,7 @@ class CleanupTest extends PHPUnit_Framework_TestCase {
         $dom->setOptions([
             'cleanupInput' => true,
         ]);
-        $dom->loadFromFile('tests/files/horrible.html');
+        $dom->loadFromFile(__DIR__ . '/../files/horrible.html');
         $this->assertEquals(0, count($dom->find('style')));
         $this->assertEquals(0, count($dom->find('script')));
     }
@@ -21,7 +21,7 @@ class CleanupTest extends PHPUnit_Framework_TestCase {
         $dom->setOptions([
             'cleanupInput' => false,
         ]);
-        $dom->loadFromFile('tests/files/horrible.html');
+        $dom->loadFromFile(__DIR__ . '/../files/horrible.html');
         $this->assertEquals(1, count($dom->find('style')));
         $this->assertEquals(1, count($dom->find('script')));
     }
@@ -32,7 +32,7 @@ class CleanupTest extends PHPUnit_Framework_TestCase {
         $dom->setOptions([
             'removeStyles' => true,
         ]);
-        $dom->loadFromFile('tests/files/horrible.html');
+        $dom->loadFromFile(__DIR__ . '/../files/horrible.html');
         $this->assertEquals(0, count($dom->find('style')));
     }
 
@@ -42,7 +42,7 @@ class CleanupTest extends PHPUnit_Framework_TestCase {
         $dom->setOptions([
             'removeStyles' => false,
         ]);
-        $dom->loadFromFile('tests/files/horrible.html');
+        $dom->loadFromFile(__DIR__ . '/../files/horrible.html');
         $this->assertEquals(1, count($dom->find('style')));
         $this->assertEquals('text/css',
             $dom->find('style')->getAttribute('type'));
@@ -54,7 +54,7 @@ class CleanupTest extends PHPUnit_Framework_TestCase {
         $dom->setOptions([
             'removeScripts' => true,
         ]);
-        $dom->loadFromFile('tests/files/horrible.html');
+        $dom->loadFromFile(__DIR__ . '/../files/horrible.html');
         $this->assertEquals(0, count($dom->find('script')));
     }
 
@@ -64,7 +64,7 @@ class CleanupTest extends PHPUnit_Framework_TestCase {
         $dom->setOptions([
             'removeScripts' => false,
         ]);
-        $dom->loadFromFile('tests/files/horrible.html');
+        $dom->loadFromFile(__DIR__ . '/../files/horrible.html');
         $this->assertEquals(1, count($dom->find('script')));
         $this->assertEquals('text/JavaScript',
             $dom->find('script')->getAttribute('type'));

--- a/tests/Options/CleanupTest.php
+++ b/tests/Options/CleanupTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHPHtmlParser\Dom;
+use PHPUnit\Framework\TestCase;
 
-class CleanupTest extends PHPUnit_Framework_TestCase {
+class CleanupTest extends TestCase {
 
     public function testCleanupInputTrue()
     {

--- a/tests/Options/PreserveLineBreaks.php
+++ b/tests/Options/PreserveLineBreaks.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHPHtmlParser\Dom;
+use PHPUnit\Framework\TestCase;
 
-class PreserveLineBreaks extends PHPUnit_Framework_TestCase {
+class PreserveLineBreaks extends TestCase {
 
     public function testPreserveLineBreakTrue()
     {

--- a/tests/Options/StrictTest.php
+++ b/tests/Options/StrictTest.php
@@ -2,8 +2,9 @@
 
 use PHPHtmlParser\Dom;
 use PHPHtmlParser\Exceptions\StrictException;
+use PHPUnit\Framework\TestCase;
 
-class StrictTest extends PHPUnit_Framework_TestCase {
+class StrictTest extends TestCase {
 
     public function testConfigStrict()
     {

--- a/tests/Options/WhitespaceTextNodeTest.php
+++ b/tests/Options/WhitespaceTextNodeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHPHtmlParser\Dom;
+use PHPUnit\Framework\TestCase;
 
-class WhitespaceTextNodeTest extends PHPUnit_Framework_TestCase {
+class WhitespaceTextNodeTest extends TestCase {
 
     public function testConfigGlobalNoWhitespaceTextNode()
     {

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHPHtmlParser\Options;
+use PHPUnit\Framework\TestCase;
 
-class OptionsTest extends PHPUnit_Framework_TestCase {
+class OptionsTest extends TestCase {
 
     public function testDefaultWhitespaceTextNode()
     {

--- a/tests/SelectorTest.php
+++ b/tests/SelectorTest.php
@@ -3,8 +3,9 @@
 use PHPHtmlParser\Selector;
 use PHPHtmlParser\Dom\HtmlNode;
 use PHPHtmlParser\Dom\Tag;
+use PHPUnit\Framework\TestCase;
 
-class SelectorTest extends PHPUnit_Framework_TestCase {
+class SelectorTest extends TestCase {
     
     public function testParseSelectorStringId()
     {

--- a/tests/StaticDomTest.php
+++ b/tests/StaticDomTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use PHPHtmlParser\Exceptions\NotLoadedException;
 use PHPHtmlParser\StaticDom;
+use PHPUnit\Framework\TestCase;
 
-class StaticDomTest extends PHPUnit_Framework_TestCase {
+class StaticDomTest extends TestCase {
 
     public function setUp()
     {
@@ -47,11 +49,9 @@ class StaticDomTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('<input type="submit" tabindex="0" name="submit" value="Информации" />', Dom::find('table input', 1)->outerHtml);
     }
 
-    /**
-     * @expectedException PHPHtmlParser\Exceptions\NotLoadedException
-     */
     public function testFindNoLoad()
     {
+        $this->expectException(NotLoadedException::class);
         StaticDom::find('.post-user font', 0);
     }
 

--- a/tests/StaticDomTest.php
+++ b/tests/StaticDomTest.php
@@ -31,19 +31,19 @@ class StaticDomTest extends PHPUnit_Framework_TestCase {
 
     public function testLoadWithFile()
     {
-        $dom = Dom::load('tests/files/small.html');
+        $dom = Dom::load(__DIR__ . '/files/small.html');
         $this->assertEquals('VonBurgermeister', $dom->find('.post-user font', 0)->text);
     }
 
     public function testLoadFromFile()
     {
-        $dom = Dom::loadFromFile('tests/files/small.html');
+        $dom = Dom::loadFromFile(__DIR__ . '/files/small.html');
         $this->assertEquals('VonBurgermeister', $dom->find('.post-user font', 0)->text);
     }
 
     public function testFind()
     {
-        Dom::load('tests/files/horrible.html');
+        Dom::load(__DIR__ . '/files/horrible.html');
         $this->assertEquals('<input type="submit" tabindex="0" name="submit" value="Информации" />', Dom::find('table input', 1)->outerHtml);
     }
 
@@ -57,7 +57,7 @@ class StaticDomTest extends PHPUnit_Framework_TestCase {
 
     public function testFindI()
     {
-        Dom::load('tests/files/horrible.html');
+        Dom::load(__DIR__ . '/files/horrible.html');
         $this->assertEquals('[ Досие бр:12928 ]', Dom::find('i')[0]->innerHtml);
     }
 
@@ -67,7 +67,7 @@ class StaticDomTest extends PHPUnit_Framework_TestCase {
         $curl->shouldReceive('get')
              ->once()
              ->with('http://google.com')
-             ->andReturn(file_get_contents('tests/files/small.html'));
+             ->andReturn(file_get_contents(__DIR__ . '/files/small.html'));
 
         Dom::loadFromUrl('http://google.com', [], $curl);
         $this->assertEquals('VonBurgermeister', Dom::find('.post-row div .post-user font', 0)->text);

--- a/tests/StaticDomTest.php
+++ b/tests/StaticDomTest.php
@@ -24,26 +24,26 @@ class StaticDomTest extends PHPUnit_Framework_TestCase {
 
     public function testLoad()
     {
-        $dom = Dom::load('<div class="all"><p>Hey bro, <a href="google.com">click here</a><br /> :)</p></div>');
+        $dom = StaticDom::load('<div class="all"><p>Hey bro, <a href="google.com">click here</a><br /> :)</p></div>');
         $div = $dom->find('div', 0);
         $this->assertEquals('<div class="all"><p>Hey bro, <a href="google.com">click here</a><br /> :)</p></div>', $div->outerHtml);
     }
 
     public function testLoadWithFile()
     {
-        $dom = Dom::load(__DIR__ . '/files/small.html');
+        $dom = StaticDom::load(__DIR__ . '/files/small.html');
         $this->assertEquals('VonBurgermeister', $dom->find('.post-user font', 0)->text);
     }
 
     public function testLoadFromFile()
     {
-        $dom = Dom::loadFromFile(__DIR__ . '/files/small.html');
+        $dom = StaticDom::loadFromFile(__DIR__ . '/files/small.html');
         $this->assertEquals('VonBurgermeister', $dom->find('.post-user font', 0)->text);
     }
 
     public function testFind()
     {
-        Dom::load(__DIR__ . '/files/horrible.html');
+        StaticDom::load(__DIR__ . '/files/horrible.html');
         $this->assertEquals('<input type="submit" tabindex="0" name="submit" value="Информации" />', Dom::find('table input', 1)->outerHtml);
     }
 
@@ -52,13 +52,13 @@ class StaticDomTest extends PHPUnit_Framework_TestCase {
      */
     public function testFindNoLoad()
     {
-        Dom::find('.post-user font', 0);
+        StaticDom::find('.post-user font', 0);
     }
 
     public function testFindI()
     {
-        Dom::load(__DIR__ . '/files/horrible.html');
-        $this->assertEquals('[ Досие бр:12928 ]', Dom::find('i')[0]->innerHtml);
+        StaticDom::load(__DIR__ . '/files/horrible.html');
+        $this->assertEquals('[ Досие бр:12928 ]', StaticDom::find('i')[0]->innerHtml);
     }
 
     public function testLoadFromUrl()
@@ -69,8 +69,8 @@ class StaticDomTest extends PHPUnit_Framework_TestCase {
              ->with('http://google.com')
              ->andReturn(file_get_contents(__DIR__ . '/files/small.html'));
 
-        Dom::loadFromUrl('http://google.com', [], $curl);
-        $this->assertEquals('VonBurgermeister', Dom::find('.post-row div .post-user font', 0)->text);
+        StaticDom::loadFromUrl('http://google.com', [], $curl);
+        $this->assertEquals('VonBurgermeister', StaticDom::find('.post-row div .post-user font', 0)->text);
     }
 
 }


### PR DESCRIPTION
* Drop PHP 5.6 and 7.0 (no longer supported)
* Drop HHVM (never really cared)
* Fix invalid usage of `mb_eregi_replace` (if you're getting stuff with mixed encoding, this breaks horribly in PHP 7.1+)
* Fix invalid usage of `count` in PHP 7.2