### PR TITLE
check for string length when using is_file()

### DIFF
--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -137,7 +137,7 @@ class Dom
     {
         AbstractNode::resetCount();
         // check if it's a file
-        if (strpos($str, "\n") === false && is_file($str)) {
+        if (strpos($str, "\n") === false && strlen($str) <= PHP_MAXPATHLEN && is_file($str)) {
             return $this->loadFromFile($str, $options);
         }
         // check if it's a url


### PR DESCRIPTION
If the string length excedes the PHP_MAXPATHLEN value, is_file() should not be called.