### PR TITLE
Ignore ; or space after charset in meta tag

### DIFF
--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -633,7 +633,7 @@ class Dom
             return false;
         }
         $matches = [];
-        if (preg_match('/charset=(.+)/', $content, $matches)) {
+        if (preg_match('/charset=([^; ]+)/', $content, $matches)) {
             $encode->from(trim($matches[1]));
             $this->root->propagateEncoding($encode);
 

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -70,8 +70,8 @@ abstract class AbstractNode
     public function __get($key)
     {
         // check attribute first
-        if ( ! is_null($this->getAttribute($key))) {
-            return $this->getAttribute($key);
+        if ( ! is_null($value = $this->getAttribute($key))) {
+            return $value;
         }
         switch (strtolower($key)) {
             case 'outerhtml':

--- a/src/PHPHtmlParser/Dom/Tag.php
+++ b/src/PHPHtmlParser/Dom/Tag.php
@@ -146,6 +146,7 @@ class Tag
             $value = [
                 'value'       => $value,
                 'doubleQuote' => true,
+                'didConvertCharset' => true, 
             ];
         }
         $this->attr[$key] = $value;
@@ -217,9 +218,10 @@ class Tag
             return null;
         }
         $value = $this->attr[$key]['value'];
-        if (is_string($value) && ! is_null($this->encode)) {
+        if (is_string($value) && ! is_null($this->encode) && ! ($this->attr[$key]['didConvertCharset'] ?? false)) {
             // convert charset
             $this->attr[$key]['value'] = $this->encode->convert($value);
+            $this->attr[$key]['didConvertCharset'] = true;
         }
 
         return $this->attr[$key];

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -33,6 +33,13 @@ class DomTest extends TestCase {
         $div = $dom->find('div', 0);
         $this->assertEquals(null, $div->foo);
     }
+    public function testIncorrectContentType()
+    {
+        $dom = new Dom;
+        $dom->load('<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8;"></head><body><div class="all"><p>Hey bro, <a href="google.com">click here</a><br /> :)</p></div></body></html>');
+        $a = $dom->find('a', 0);
+        $this->assertEquals($a->text, 'click here');
+    }
 
     public function testLoadSelfclosingAttr()
     {

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -41,6 +41,14 @@ class DomTest extends TestCase {
         $this->assertEquals($a->text, 'click here');
     }
 
+    public function testCharsetConvertInAttribute()
+    {
+        $dom = new Dom;
+        $dom->loadFromFile(__DIR__ . '/files/ISO-8859-7.html', ['preserveLineBreaks' => true]);
+        $a = $dom->find('a', 0);
+        $this->assertEquals('/testη', $a->href);
+    }
+
     public function testLoadSelfclosingAttr()
     {
         $dom = new Dom;

--- a/tests/files/ISO-8859-7.html
+++ b/tests/files/ISO-8859-7.html
@@ -1,0 +1,8 @@
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-7">
+	</head>
+	<body>
+		<a href="/testη">EEη<span>XX</span></a>
+	</body>
+</html>


### PR DESCRIPTION
Found some sites using: 
`<meta http-equiv="Content-Type" content="text/html; charset=UTF-8;">`

changed regex to ignore this trailing semicolon.